### PR TITLE
chore: add github workflow to add zenhub label

### DIFF
--- a/.github/workflows/add-zenhub-label.yml
+++ b/.github/workflows/add-zenhub-label.yml
@@ -1,0 +1,24 @@
+# Ensure we add the correct ZenHub label for all new issues
+# Avoids problem where checklist issues are not added to the correct ZenHub pipeline
+
+name: Add ZenHub label to issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["Ecosystem: Frameworks"]
+            })


### PR DESCRIPTION
## Description

Adds `Ecosystem: Frameworks` label for all created issues to ensure it appears on the correct ZenHub workspace. Issues which are created using GitHub checklists didn't apply the issue template and the label was missing.

## Related Tickets & Documents

- Related Issue: https://github.com/netlify/pod-ecosystem-frameworks/issues/507

## QA Instructions, Screenshots, Recordings

Updates a GitHub workflow. Check that the `Ecosystem: Frameworks` label is added when a new issue is created.

**A picture of a cute animal (not mandatory, but encouraged)**

![image](https://github.com/netlify/remix-template/assets/1965510/68d7f4f6-e762-47e3-98b9-bfce83e79020)
