### PR TITLE
(fix): Update and fix remix template dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ To use the template, run
 npx create-remix@latest --template netlify/remix-template
 ```
 
+
 This project includes:
 
 - Netlify Functions template for Remix sites
 - Netlify Edge Functions template for Remix sites
+
+From the `create-remix` command, you may pass `--netlify-edge` or `--no-netlify-edge` to generate a template that uses Netlify Edge or Serverless functions explicitly. Without passing this option, the create workflow will ask you which you would prefer.
 
 ## Development
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,11 +8,11 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
-export const meta: MetaFunction = () => ({
+export const meta: MetaFunction = () => [{
   charset: "utf-8",
   title: "New Remix App",
   viewport: "width=device-width,initial-scale=1",
-});
+}];
 
 export default function App() {
   return (

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "build": "remix build",
+    "build": "remix build && cp _app_redirects public/_redirects",
     "predev": "rimraf ./public/_redirects",
     "dev": "remix dev",
     "start": "netlify serve",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,6 @@
     "typescript": "^5.1.0"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "sideEffects": false,
   "scripts": {
-    "build": "remix build && cp _app_redirects public/_redirects",
+    "build": "remix build",
     "predev": "rimraf ./public/_redirects",
     "dev": "remix dev",
     "start": "netlify serve",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/react-dom": "^18.0.8",
     "eslint": "^8.27.0",
     "rimraf": "^4.1.4",
-    "typescript": "^4.8.4"
+    "typescript": "^5.1.0"
   },
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@netlify/functions": "^1.3.0",
-    "@remix-run/netlify": "*",
     "@remix-run/node": "*",
     "@remix-run/react": "*",
     "cross-env": "^7.0.3",

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -54,7 +54,6 @@ async function updatePackageJsonForEdge(directory) {
   const packageJson = await PackageJson.load(directory);
   const {
     dependencies: {
-      "@remix-run/netlify": _netlify,
       "@remix-run/node": _node,
       ...dependencies
     },
@@ -73,6 +72,28 @@ async function updatePackageJsonForEdge(directory) {
       ...dependencies,
       "@netlify/edge-functions": "^2.0.0",
       "@netlify/remix-edge-adapter": "1.2.0",
+    },
+  });
+
+  await packageJson.save();
+}
+
+async function updatePackageJsonForFunctions(directory) {
+  const packageJson = await PackageJson.load(directory);
+  const {
+    dependencies: {
+      "@remix-run/node": _node,
+      ...dependencies
+    },
+    scripts,
+    ...restOfPackageJson
+  } = packageJson.content;
+
+  packageJson.update({
+    ...restOfPackageJson,
+    dependencies: {
+      ...dependencies,
+      "@netlify/remix-adapter": "^1.0.0",
     },
   });
 
@@ -107,7 +128,7 @@ async function main({ rootDirectory, isTypeScript }) {
       rootDirectory,
       isTypeScript,
     });
-
+    await updatePackageJsonForFunctions(rootDirectory);
     return;
   }
 

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -3,6 +3,7 @@ const fs = require("fs/promises");
 const { join } = require("path");
 const PackageJson = require("@npmcli/package-json");
 const execa = require("execa");
+const { Command } = require('commander');
 
 const foldersToExclude = [".github", ".git"];
 
@@ -138,25 +139,38 @@ async function main({ rootDirectory }) {
 }
 
 async function shouldUseEdge() {
-  const { edge } = await inquirer.prompt([
-    {
-      name: "edge",
-      type: "list",
-      message: "Run your Remix site with:",
-      choices: [
-        {
-          name: "Netlify Functions",
-          value: false,
-        },
-        {
-          name: "Netlify Edge Functions",
-          value: true,
-        },
-      ],
-    },
-  ]);
 
-  return edge;
+  // parse the top level command args to see if edge was passed in
+  const program = new Command();
+  program
+    .option('--netlify-edge', 'explicitly use Netlify Edge Functions to serve this Remix site.', undefined)
+    .option('--no-netlify-edge', 'explicitly do NOT use Netlify Edge Functions to serve this Remix site - use Serverless Functions instead.', undefined)
+  program.allowUnknownOption().parse();
+
+  const passedEdgeOption = program.opts().netlifyEdge;
+
+  if(passedEdgeOption !== true && passedEdgeOption !== false){
+    const { edge } = await inquirer.prompt([
+      {
+        name: "edge",
+        type: "list",
+        message: "Run your Remix site with:",
+        choices: [
+          {
+            name: "Netlify Functions",
+            value: false,
+          },
+          {
+            name: "Netlify Edge Functions",
+            value: true,
+          },
+        ],
+      },
+    ]);
+    return edge;
+  }
+
+  return passedEdgeOption;
 }
 
 module.exports = main;

--- a/remix.init/package.json
+++ b/remix.init/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
+    "commander": "^11.0.0",
     "inquirer": "^8.2.2"
   }
 }

--- a/remix.init/root.tsx
+++ b/remix.init/root.tsx
@@ -8,11 +8,13 @@ import {
   ScrollRestoration,
 } from "@remix-run/react";
 
-export const meta: MetaFunction = () => ({
-  charset: "utf-8",
-  title: "New Remix App",
-  viewport: "width=device-width,initial-scale=1",
-});
+export const meta: MetaFunction = () => [
+  {
+    charset: "utf-8",
+    title: "New Remix App",
+    viewport: "width=device-width,initial-scale=1",
+  }
+];
 
 export default function App() {
   return (

--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-import { createRequestHandler } from "@remix-run/netlify";
+import { createRequestHandler } from "@netlify/remix-adapter";
 import * as build from "@remix-run/dev/server-build";
 
 export const handler = createRequestHandler({


### PR DESCRIPTION
## Description

This PR fixes and changes a couple of things related to setup of remix projects with netlify. Here are the list of current issues.

- Currently the projects scaffolded with the default command don't work. Reason, `@remix-run/netlify` is currently deprecated in favour of `@netlify/edge-adapter`. But the default template is still using `@remix-run/netlify` https://github.com/netlify/remix-template/blob/main/package.json#L13
So, at the time of `remix init` it is copying the semver version of `remix` which is currently `2` which doesn't exist in `npm`. 

Copy step inside remix cli -> https://github.com/remix-run/remix/blob/9b280fe597258c7807844f11cec3dd0fd7937997/packages/create-remix/index.ts#L725

- Second at the step of setting up the template. the template need to drop the usage of `@remix-run/netlify` to `@netlify/remix-adapter` everywhere.
Reference -> https://github.com/remix-run/remix/blob/9b280fe597258c7807844f11cec3dd0fd7937997/docs/start/v2.md?plain=1#L1057

- Change the meta exports, `remix` expects the meta export now a array of objects instead of just a single object.
