### PR TITLE
feat: replace _redirects workaround with preferStatic

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,3 +1,1 @@
 export { handleRequest as default } from "@netlify/remix-adapter";
-
-export const config = { path: "/*", preferStatic: true };

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,1 +1,3 @@
 export { handleRequest as default } from "@netlify/remix-adapter";
+
+export const config = { path: "/*", preferStatic: true };

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -19,11 +19,7 @@ const edgeFilesToCopy = [
 ];
 
 // Netlify Functions template file changes
-const filesToCopy = [
-  ["README.md"],
-  ["netlify-toml", "netlify.toml"],
-  ["redirects", ".redirects"],
-];
+const filesToCopy = [["README.md"], ["netlify-toml", "netlify.toml"]];
 
 async function copyTemplateFiles({ files, rootDirectory }) {
   for (const [file, target] of files) {
@@ -65,26 +61,14 @@ async function updatePackageJsonForEdge(directory) {
 
 async function updatePackageJsonForFunctions(directory) {
   const packageJson = await PackageJson.load(directory);
-  const {
-    dependencies: { "@remix-run/node": _node, ...dependencies },
-    scripts,
-    ...restOfPackageJson
-  } = packageJson.content;
+  const { dependencies, ...restOfPackageJson } = packageJson.content;
 
   packageJson.update({
     ...restOfPackageJson,
-    scripts: {
-      ...scripts,
-      build: "npm run redirects:enable && remix build",
-      dev: "npm run redirects:disable && remix dev",
-      "redirects:enable": "shx cp .redirects public/_redirects",
-      "redirects:disable": "shx rm -f public/_redirects",
-    },
     dependencies: {
       ...dependencies,
       "@netlify/functions": "^2.0.0",
       "@netlify/remix-adapter": "^2.0.0",
-      shx: "^0.3.4",
     },
   });
 

--- a/remix.init/redirects
+++ b/remix.init/redirects
@@ -1,4 +1,0 @@
-# This file is copied into the public folder during the build step and removed during dev.
-# If you need to add your own redirects, add them in netlify.toml or they will be overwritten.
-# Do not remove the line below. This is required to serve the site when deployed.
-/* /.netlify/functions/server 200

--- a/server.ts
+++ b/server.ts
@@ -7,3 +7,5 @@ const handler = createRequestHandler({
 });
 
 export default handler;
+
+export const config = { path: "/*", preferStatic: true }


### PR DESCRIPTION
It's important that the SSR function matches all paths, except for the ones that have static files. In the past, `_redirects` was the way to achieve that - but with V2 Functions, in-source-config is much easier to reason about. Now that we have `preferStatic`, we can scratch the `_redirects` workaround and use in-source-config instead!

Keeping this as draft until i've manually verified that it works as intended. One of the challenges is that the Remix compiler will turn `true` into `!0`, but https://github.com/netlify/zip-it-and-ship-it/pull/1665 should help us handle that.