### PR TITLE
chore: add entry.server.tsx to functions template

### DIFF
--- a/remix.init/functions/app/entry.server.tsx
+++ b/remix.init/functions/app/entry.server.tsx
@@ -1,0 +1,79 @@
+import { PassThrough } from "node:stream";
+
+import type { AppLoadContext, EntryContext } from "@remix-run/node";
+import { createReadableStreamFromReadable } from "@remix-run/node";
+import { RemixServer } from "@remix-run/react";
+import { isbot } from "isbot";
+import { renderToPipeableStream } from "react-dom/server";
+
+const ABORT_DELAY = 5_000;
+
+export default function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  loadContext: AppLoadContext
+) {
+  const bot = isbot(request.headers.get("user-agent"));
+  return new Promise((resolve, reject) => {
+    let shellRendered = false;
+    const body = new PassThrough();
+    const stream = createReadableStreamFromReadable(body);
+
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer
+        context={remixContext}
+        url={request.url}
+        abortDelay={ABORT_DELAY}
+      />,
+      {
+        onShellReady() {
+          if (!bot) {
+            shellRendered = true;
+            responseHeaders.set("Content-Type", "text/html");
+            resolve(
+              new Response(stream, {
+                headers: responseHeaders,
+                status: responseStatusCode,
+              })
+            );
+            pipe(body);
+          }
+        },
+        onShellError(error: unknown) {
+          reject(error);
+        },
+        onAllReady() {
+          // Avoid a bug where responses aren't flushed if there's an outstanding timer.
+          clearTimeout(timer);
+          if (bot) {
+            shellRendered = true;
+            responseHeaders.set("Content-Type", "text/html");
+            resolve(
+              new Response(stream, {
+                headers: responseHeaders,
+                status: responseStatusCode,
+              })
+            );
+            pipe(body);
+          }
+        },
+        onError(error: unknown) {
+          responseStatusCode = 500;
+          // Log streaming rendering errors from inside the shell.  Don't log
+          // errors encountered during initial shell rendering since they'll
+          // reject and get logged in handleDocumentRequest.
+          if (shellRendered) {
+            console.error(error);
+          }
+        },
+      }
+    );
+
+    const timer = setTimeout(() => {
+      abort();
+    }, ABORT_DELAY);
+  });
+}


### PR DESCRIPTION
## Description

Seems like default Remix server entry is behaving weirdly and is not closing connection after send content and only eventually after 5s (default timeout) connection is closed which is reported as slow response ( https://answers.netlify.com/t/remix-very-slow/115440 )

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## QA Instructions, Screenshots, Recordings

_Please replace this line with instructions on how to test your changes_

For us to review and ship your PR efficiently, please perform the following steps:

- [ ] Open a [bug/issue](https://github.com/netlify/remix-edge-template/issues/new/choose) before writing your code 🧑‍💻. This ensures we
      can discuss the changes and get feedback from everyone that should be involved. If you\`re fixing a typo or
      something that\`s on fire 🔥 (e.g. incident related), you can skip this step.
- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 📖. This ensures your code follows our style
      guide and passes our tests.
- [ ] Update or add tests (if any source code was changed or added) 🧪
- [ ] Update or add documentation (if features were changed or added) 📝
- [ ] Make sure the status checks below are successful ✅

**A picture of a cute animal (not mandatory, but encouraged)**
