### PR TITLE
fix: correct imports in index page

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -1,1 +1,0 @@
-export { handleRequest as default } from "@netlify/remix-adapter";

--- a/remix.init/edge/app/routes/_index.tsx
+++ b/remix.init/edge/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import type { MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@netlify/remix-runtime";
 
 export const meta: MetaFunction = () => {
   return [

--- a/remix.init/index.js
+++ b/remix.init/index.js
@@ -143,7 +143,6 @@ async function shouldUseEdge(rootDirectory) {
 
 async function main({ rootDirectory, packageManager }) {
   intro(`Welcome to Remix on Netlify`);
-  console.log("rootDirectory", rootDirectory);
   const useEdge = await shouldUseEdge(rootDirectory);
   const spin = spinner();
   spin.start("Setting up your project");


### PR DESCRIPTION
## Description

Updates the template to import from `@netlify/remix-runtime` on edge and `@remix-run/node` on functions. Also removes the entrypoint for Node, as it's no longer needed with the fixes to lambda streaming